### PR TITLE
Bug fix: add `kernel_size` parameter

### DIFF
--- a/cvnets/models/classification/mobilenetv3.py
+++ b/cvnets/models/classification/mobilenetv3.py
@@ -193,6 +193,7 @@ class MobileNetV3(BaseEncoder):
                     dilation=prev_dilation if count == 0 else self.dilation,
                     act_fn_name="hard_swish" if use_hs else "relu",
                     use_se=use_se,
+                    kernel_size=kernel_size,
                 )
                 mv3_block.add_module(name=block_name, module=layer)
                 count += 1


### PR DESCRIPTION
MobileNet v3 uses 5x5 convolutions in its model architecture. However, the kernel size is not reflected in the Inverse Residual module.
Change: added the `kernel_size` parameter to reflect MobileNetV3 configurations in `_make_layer`.