### PR TITLE
Fixed the missing token normalization for cross-attention computation

### DIFF
--- a/cvnets/modules/transformer.py
+++ b/cvnets/modules/transformer.py
@@ -255,6 +255,7 @@ class LinearAttnFFN(BaseModule):
             # cross-attention
             res = x
             x = self.pre_norm_attn[0](x)  # norm
+            x_prev = self.pre_norm_attn[0](x_prev)  # normalize x_prev as well!
             x = self.pre_norm_attn[1](x, x_prev)  # attn
             x = self.pre_norm_attn[2](x)  # drop
             x = x + res  # residual


### PR DESCRIPTION
For a downstream task, I see better training convergence upon normalizing both _x_ and _x_prev_ during the computation of cross-attention here: https://github.com/apple/ml-cvnets/blob/main/cvnets/modules/transformer.py#L258

Currently, I am conducting model training with and without the proposed normalization of _x_prev_ and will share the results for the two cases. In the meantime, if this change makes sense, kindly include it. Let me know if you need any related info.